### PR TITLE
Fix title matching for iOS devices

### DIFF
--- a/src/lib/utils/parse.ts
+++ b/src/lib/utils/parse.ts
@@ -30,7 +30,7 @@ const sanitizeURL = async ({ message }: Util): Promise<string> => {
 export const messageToString = ({ message }: Util): string => message.replace(createRegExp, '');
 
 export const parseSpoilerText = async ({ message }: Util): Promise<SpoilerInfo> => {
-    const name = message.match(/"((?:\\.|[^"\\])*)"/);
+    const name = message.match(/["“]((?:\\.|[^"\\])*)[”"]/);
     const sanitize = message.replace(/\s*"((?:\\.|[^"\\])*)"\s*/, '');
 
     return {


### PR DESCRIPTION
Add missing support to the left/right double quotation marks used by iOS devices.
Now spoiler names can be written either in "" or in “”.